### PR TITLE
[chore]: sync dep versions back up

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
 
  :deps  {org.clojure/clojure         {:mvn/version "1.11.1"}
-         com.cognitect.aws/api       {:mvn/version "0.8.686"}
-         com.cognitect.aws/endpoints {:mvn/version "1.1.12.504"}
+         com.cognitect.aws/api       {:mvn/version "0.8.681"}
+         com.cognitect.aws/endpoints {:mvn/version "1.1.12.489"}
          com.cognitect.aws/sqs       {:mvn/version "847.2.1398.0"}
          org.clojure/core.async      {:mvn/version "1.6.681"}
          org.clojure/tools.logging   {:mvn/version "1.2.4"}}


### PR DESCRIPTION
I _think_ these deps are out of sync. 
- https://github.com/cognitect-labs/aws-api/blob/main/latest-releases.edn#L1 vs https://github.com/RutledgePaulV/piped/blob/master/deps.edn#L4
- https://github.com/cognitect-labs/aws-api/blob/main/latest-releases.edn#L2 vs https://github.com/RutledgePaulV/piped/blob/master/deps.edn#L5


I'm seeing an error running a queue processor against a localstack queue:
```
; eval (current-form): (piped/stop @sut/webhook-processor)
; (err) Execution error (ExceptionInfo) at cognitect.aws.service/service-description (service.clj:33).
; (err) Cannot find resource cognitect/aws/sqs/service.edn.
```