### PR TITLE
Add acker batch size as an option

### DIFF
--- a/src/piped/core.clj
+++ b/src/piped/core.clj
@@ -65,7 +65,8 @@
            acker-parallelism
            nacker-parallelism
            blocking-consumers
-           queue-visibility-timeout-seconds]
+           queue-visibility-timeout-seconds
+           acker-batch-size]
     :as   opts}]
 
   (specs/assert-options opts)
@@ -84,7 +85,7 @@
                   acker-chan           (async/chan)
                   nacker-chan          (async/chan)
                   pipe                 (async/chan)
-                  acker-batched        (utils/deadline-batching acker-chan 10)
+                  acker-batched        (utils/deadline-batching acker-chan (or acker-batch-size 10))
                   nacker-batched       (utils/combo-batching nacker-chan 5000 10)
                   composed-consumer    (if transform-fn (comp consumer-fn transform-fn) consumer-fn)]
 

--- a/src/piped/specs.clj
+++ b/src/piped/specs.clj
@@ -13,6 +13,7 @@
 (s/def :piped/extend #{:extend})
 (s/def :piped/delay-seconds nat-int?)
 (s/def :piped/queue-visibility-timeout-seconds pos-int?)
+(s/def :piped/acker-batch-size pos-int?)
 (s/def :piped/action-map
   (s/keys
     :req-un [:piped/action]
@@ -33,7 +34,8 @@
             :piped/nacker-parallelism
             :piped/blocking-consumers
             :piped/transform-fn
-            :piped/queue-visibility-timeout-seconds]))
+            :piped/queue-visibility-timeout-seconds
+            :piped/acker-batch-size]))
 
 (defn assert-options [config]
   (if-not (s/valid? :piped/options-map config)


### PR DESCRIPTION
We have certain tests that wait for queues to be empty before proceeding. We want to reduce the acker batch size to 1 so that we don't have to wait for the visibility timeout to near an end before the queues are empty. So we're hoping to get this option added. 